### PR TITLE
Revise English in the intro in the documentation

### DIFF
--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -1,11 +1,13 @@
 Introduction
 ==============================
-Cascade is:
+Cascade is GREE's data access library for PHP
+which offers an unified interface for accessing various kind of backends such as:
 
-* offering the integrated interface without considering of any kind of storages.
-* concealing the logic of data access into the inside.
+* databases
+* files
+* caching systems
 
-Supported functions
+Supported backends
 ------------------------------
 * SQL mode
 
@@ -26,11 +28,11 @@ Supported functions
 
 Design
 ------------------------------
-* Simple access
+* Simple data access
 * Extendibility
 
 
-Data access sample::
+Data access example::
 
   require_once 'Cascade.php'
 


### PR DESCRIPTION
Hi,

Thanks for sharing this!

Though I'm not a native English writer, 
I have some suggestions to make your documents a bit more concise.

You should:
- at first write a what-it-is in the "Cascade is a _blah-blah-blah_ which does _some cool things for us programmers_" form
- not just repeat the same explanation in different terms, not to confuse the readers
- differentiate "unified" from "integrated"
- use more concrete words than "storage" because it may be taken as "computer component/physical device to retain data", but not relational/NoSQL databases, files, caching systems that you meant.

You might:
- prefer being more concise. "Simple access" to what?
- prefer "example" over "sample" in this case

Forgive me if I'm being rude.
I hope this helps!

Regards,

Yusuke
