### PR TITLE
IDE friendly doc block for Cascade_Proxy_PassThroughGateway.

### DIFF
--- a/class/Cascade.php
+++ b/class/Cascade.php
@@ -21,8 +21,15 @@ final class Cascade
      *
      *  @param   string                   識別子
      *  @return  Cascade_Proxy_Gateway  ゲートウェイ
+     *
+     *  NOTE: Basically Cascade::getAccessor returns Cascade_Proxy_PassThroughGateway as a default proxy class.
+     *  you can use method hint with this annotation on some IDE.
+     *
+     *    $accessor = Cascade::getAccessor("namespace#data_format");
+     *    // @var $accessor Cascade_Proxy_PassThroughGateway
+     *
      */
-    public static /* Cascade_Proxy_DBGateway */
+    public static /* Cascade_Proxy_Gateway */
         function getAccessor(/* string */ $schema_name)
     {
         return Cascade_Proxy_Gateway::getInstance($schema_name);

--- a/class/Cascade/Proxy/PassThroughGateway.php
+++ b/class/Cascade/Proxy/PassThroughGateway.php
@@ -14,6 +14,51 @@
  *
  *  @author   Yoshinobu Kinugasa <kinugasa@gree.co.jp>
  *  @package  Cascade_Proxy
+ *
+ *  [Common Methods]
+ *
+ *  @method mixed get($key, $hint_or_section = NULL, $use_master_or_name = false)
+ *      hint and use_master parameters are used for `Cascade_Facade_SQL`. section and name are used for Cascade_Facade_Config.
+ *
+ *  @method mixed mget($keys, $hint = null, $use_master = false)
+ *      hint and use_master parameter are used for `Cascade_Facade_SQL`. `Cascade_Facade_Config` does not support this method.
+ *
+ *  [Facade/KVS methods]
+ *  @see Cascade_Facade_KVS
+ *
+ *  @method boolean add($key, $value, $expiration = 0)
+ *  @method boolean set($key, $value, $expiration = 0)
+ *  @method boolean replace($key, $value, $expiration = 0)
+ *  @method boolean cas($cas_token,  $key, $value, $expiration = 0)
+ *  @method boolean delete($key)
+ *  @method int increment($key, $offset = 1)
+ *  @method int decrement($key, $offset = 1)
+ *  @method int getErrorCode()
+ *  @method string getErrorMessage()
+ *
+ *  [Facade/SQL methods]
+ *  @see Cascade_Facade_SQL
+ *
+ *  @method mixed getEx($extra_dsn, $key, $hint = NULL, $use_master = false)
+ *  @method mixed mgetEx($extra_dsn, $keys, $hint = null, $use_master = false)
+ *  @method mixed findFirst($stmt_name, $params = null, $hint = null, $use_master = false)
+ *  @method mixed findFirstEx($extra_dsn, $stmt_name, $params = null, $hint = null, $use_master = false)
+ *  @method mixed find($stmt_name, $params = null, $offset = null, $limit = null, $hint = null,  $use_master = false)
+ *  @method mixed findEx($extra_dsn, $stmt_name, $params = null, $offset = null, $limit = null, $hint = null, $use_master = false)
+ *  @method mixed toValue($stmt_name, $params = null, $hint = null, $use_master = false])
+ *  @method mixed toValueEx($extra_dsn, $stmt_name, $params = null, $hint = null, $use_master = false)
+ *  @method mixed execute($stmt_name, $params = null, $hint = null)
+ *  @method int lastInsertId($hint = null)
+ *  @method boolean beginTransaction($hint = null)
+ *  @method boolean commit($hint = null)
+ *  @method boolean rollback($hint = null)
+ *  @method int createDb($hint = null)
+ *
+ *  [Facade/Config methods]
+ *  @see Cascade_Facade_Config
+ *
+ *  @method mixed getAll()
+ *  @method int count()
  */
 final class Cascade_Proxy_PassThroughGateway
     extends Cascade_Proxy_Gateway


### PR DESCRIPTION
たまにCascade初心者がgetAccessorの帰り値で混乱するのでこんな感じでmagic method用のdoc blockとコメントを追加しておきました。

IDEを使っていればこんな感じでmethod hintが出るようになるので幸せになれるはず

```
  $accessor = Cascade::getAccessor("namespace#data_format");
  /* @var $accessor Cascade_Proxy_PassThroughGateway */
```
