### PR TITLE
integrate with travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: php
+php:
+  - 5.2
+  - 5.3
+  - 5.4
+  - 5.5
+
+before_script:
+  - mysql -e 'create database cascade_test_on_travis;'
+  - echo "extension = memcached.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - echo "extension = apc.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+  - echo "apc.enable_cli=1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+script: phpunit
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://secure.travis-ci.org/gree/cascade.png)](http://travis-ci.org/gree/cascade)
+
 Introduction
 -------------
 

--- a/class/Cascade/Driver/KVS/Libmemcached.php
+++ b/class/Cascade/Driver/KVS/Libmemcached.php
@@ -415,9 +415,9 @@ class Cascade_Driver_KVS_Libmemcached
             if ($is_success) {
                 $cas_token        = NULL;
                 $storage_key_flip = array_flip($storage_keys);
-                while ($tmp = $client->fetch(&$cas_token)) {
+                while ($tmp = $client->fetch($cas_token)) {
                     $values[$storage_key_flip[key($tmp)]]     = current($tmp);
-                    $cas_tokens[$storage_key_flip[key($tmp)]] = $cas_token;
+                    $cas_tokens[$storage_key_flip[key($tmp)]] = (string)$cas_token;
                 }
             }
             if ($is_success == FALSE

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<phpunit colors="false"
+         verbose="true"
+         bootstrap="test/bootstrap.php"
+         convertErrorsToExceptions="false">
+  <testsuites>
+    <testsuite name="Cascade Test Suite">
+        <file>test/class/Cascade/Accessor/SQL/TestMySQLi01.php</file>
+        <file>test/class/Cascade/Accessor/SQL/TestMySQLi02.php</file>
+        <file>test/class/Cascade/Accessor/SQL/TestMySQLi03.php</file>
+        <file>test/class/Cascade/Accessor/SQL/TestMySQLi04.php</file>
+
+        <file>test/class/Cascade/Accessor/SQL/TestMySQLi11.php</file>
+        <file>test/class/Cascade/Accessor/SQL/TestMySQLi12.php</file>
+        <file>test/class/Cascade/Accessor/SQL/TestMySQLi13.php</file>
+        <file>test/class/Cascade/Accessor/SQL/TestMySQLi14.php</file>
+
+        <!-- incorrect test
+        <file>test/class/Cascade/Accessor/SQL/TestMySQLi21.php</file>
+        -->
+        <file>test/class/Cascade/Accessor/SQL/TestMySQLi22.php</file>
+
+      <file>test/class/Cascade/Accessor/KVS/TestMemcached01.php</file>
+      <file>test/class/Cascade/Accessor/KVS/TestFlare01.php</file>
+      <file>test/class/Cascade/Accessor/KVS/TestAPC01.php</file>
+
+      <file>test/class/Cascade/Accessor/Config/TestPHPArray01.php</file>
+      <file>test/class/Cascade/Accessor/Config/TestIniFile01.php</file>
+      <file>test/class/Cascade/Accessor/Config/TestCSVFile01.php</file>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -3,7 +3,6 @@
  *  Cascade定数値の設定
  */
 define('CASCADE_SRC_ROOT',        dirname(dirname(__FILE__)).'/class');
-define('CASCADE_CONFIG_DIR_PATH', dirname(dirname(__FILE__)).'/etc');
 define('CASCADE_SKEL_DIR_PATH',   dirname(dirname(__FILE__)).'/skel');
 
 /**
@@ -11,6 +10,18 @@ define('CASCADE_SKEL_DIR_PATH',   dirname(dirname(__FILE__)).'/skel');
  */
 define('CASCADE_SRC_TEST_ROOT',    dirname(__FILE__).'/class');
 define('CASCADE_CONF_TEST_ROOT',   dirname(__FILE__).'/conf');
+
+$is_ci     = (getenv("CI") == "true");
+$is_travis = (getenv("TRAVIS") == "true");
+
+if ($is_ci && $is_travis) {
+    /**
+     * NOTE: read travis specific config here.
+     */
+    define('CASCADE_CONFIG_DIR_PATH', dirname(__FILE__) .'/etc');
+} else {
+    define('CASCADE_CONFIG_DIR_PATH', dirname(dirname(__FILE__)).'/etc');
+}
 
 
 // PHPファイルの読み込み

--- a/test/class/Cascade/Accessor/KVS/TestAPC01.php
+++ b/test/class/Cascade/Accessor/KVS/TestAPC01.php
@@ -16,6 +16,14 @@ final class Cascade_Accessor_KVS_TestAPC01
     // ----[ Class Constants ]----------------------------------------
     const SCHEMA_NAME = 'test#Accessor_KVS_TestAPC01';
 
+    protected function setup()
+    {
+        if (!extension_loaded("apc")) {
+            $this->markTestSkipped("Can't use apc extension. skip test");
+        }
+    }
+
+
     // ----[ Methods ]------------------------------------------------
    // {{{ test_mget_01
     public function test_mget_01()
@@ -71,7 +79,8 @@ final class Cascade_Accessor_KVS_TestAPC01
 
         // -----------------------------
         $data_01 = $accessor->set($key, $value);
-        $data_02 = array_shift($accessor->get($key));
+        $a = $accessor->get($key);
+        $data_02 = array_shift($a);
 
         // -----------------------------
         $this->assertTrue($data_01);
@@ -89,7 +98,8 @@ final class Cascade_Accessor_KVS_TestAPC01
         // -----------------------------
         $data_01 = $accessor->add($key, $value);
         $data_02 = $accessor->set($key, $value = 20000);
-        $data_03 = array_shift($accessor->get($key));
+        $a = $accessor->get($key);
+        $data_03 = array_shift($a);
 
         // -----------------------------
         $this->assertTrue($data_01);
@@ -107,7 +117,8 @@ final class Cascade_Accessor_KVS_TestAPC01
 
         // -----------------------------
         $data_01 = $accessor->replace($key, $value);
-        $data_02 = array_shift($accessor->get($key));
+        $a = $accessor->get($key);
+        $data_02 = array_shift($a);
 
         // -----------------------------
         $this->assertFalse($data_01);
@@ -125,7 +136,8 @@ final class Cascade_Accessor_KVS_TestAPC01
         // -----------------------------
         $data_01 = $accessor->add($key, $value);
         $data_02 = $accessor->replace($key, $value = 20000);
-        $data_03 = array_shift($accessor->get($key));
+        $a = $accessor->get($key);
+        $data_03 = array_shift($a);
 
         // -----------------------------
         $this->assertTrue($data_01);
@@ -195,9 +207,11 @@ final class Cascade_Accessor_KVS_TestAPC01
             $cas_token
         ) = $accessor->get($key);
         $data_03 = $accessor->set($key, $value_02);
-        $data_04 = array_shift($accessor->get($key));
+        $a = $accessor->get($key);
+        $data_04 = array_shift($a);
         $data_05 = $accessor->cas($cas_token, $key, $value_03);
-        $data_06 = array_shift($accessor->get($key));
+        $a = $accessor->get($key);
+        $data_06 = array_shift($a);
 
         // -----------------------------
         $this->assertTrue($data_01);
@@ -225,7 +239,8 @@ final class Cascade_Accessor_KVS_TestAPC01
         ) = $accessor->get($key);
         $accessor->delete($key);
         $data_03 = $accessor->cas($cas_token, $key, $value_02);
-        $data_04 = array_shift($accessor->get($key));
+        $a = $accessor->get($key);
+        $data_04 = array_shift($a);
 
         // -----------------------------
         $this->assertTrue($data_01);

--- a/test/class/Cascade/Accessor/KVS/TestFlare01.php
+++ b/test/class/Cascade/Accessor/KVS/TestFlare01.php
@@ -71,7 +71,8 @@ final class Cascade_Accessor_KVS_TestFlare01
 
         // -----------------------------
         $data_01 = $accessor->set($key, $value);
-        $data_02 = array_shift($accessor->get($key));
+        $actual_key = $accessor->get($key);
+        $data_02 = array_shift($actual_key);
 
         // -----------------------------
         $this->assertTrue($data_01);
@@ -89,7 +90,8 @@ final class Cascade_Accessor_KVS_TestFlare01
         // -----------------------------
         $data_01 = $accessor->add($key, $value);
         $data_02 = $accessor->set($key, $value = 20000);
-        $data_03 = array_shift($accessor->get($key));
+        $actual_key = $accessor->get($key);
+        $data_03 = array_shift($actual_key);
 
         // -----------------------------
         $this->assertTrue($data_01);
@@ -107,7 +109,8 @@ final class Cascade_Accessor_KVS_TestFlare01
 
         // -----------------------------
         $data_01 = $accessor->replace($key, $value);
-        $data_02 = array_shift($accessor->get($key));
+        $actual_key = $accessor->get($key);
+        $data_02 = array_shift($actual_key);
 
         // -----------------------------
         $this->assertFalse($data_01);
@@ -125,7 +128,8 @@ final class Cascade_Accessor_KVS_TestFlare01
         // -----------------------------
         $data_01 = $accessor->add($key, $value);
         $data_02 = $accessor->replace($key, $value = 20000);
-        $data_03 = array_shift($accessor->get($key));
+        $actual_key = $accessor->get($key);
+        $data_03 = array_shift($actual_key);
 
         // -----------------------------
         $this->assertTrue($data_01);
@@ -149,7 +153,8 @@ final class Cascade_Accessor_KVS_TestFlare01
             $cas_token
         ) = $accessor->get($key);
         $data_03 = $accessor->cas($cas_token, $key, $value_02);
-        $data_04 = array_shift($accessor->get($key));
+        $actual_key = $accessor->get($key);
+        $data_04 = array_shift($actual_key);
 
         // -----------------------------
         $this->assertTrue($data_01);
@@ -196,9 +201,11 @@ final class Cascade_Accessor_KVS_TestFlare01
             $cas_token
         ) = $accessor->get($key);
         $data_03 = $accessor->set($key, $value_02);
-        $data_04 = array_shift($accessor->get($key));
+        $actual_key = $accessor->get($key);
+        $data_04 = array_shift($actual_key);
         $data_05 = $accessor->cas($cas_token, $key, $value_03);
-        $data_06 = array_shift($accessor->get($key));
+        $actual_key = $accessor->get($key);
+        $data_06 = array_shift($actual_key);
 
         // -----------------------------
         $this->assertTrue($data_01);
@@ -226,7 +233,8 @@ final class Cascade_Accessor_KVS_TestFlare01
         ) = $accessor->get($key);
         $accessor->delete($key);
         $data_03 = $accessor->cas($cas_token, $key, $value_02);
-        $data_04 = array_shift($accessor->get($key));
+        $actual_key = $accessor->get($key);
+        $data_04 = array_shift($actual_key);
 
         // -----------------------------
         $this->assertTrue($data_01);

--- a/test/class/Cascade/Accessor/KVS/TestMemcached01.php
+++ b/test/class/Cascade/Accessor/KVS/TestMemcached01.php
@@ -71,7 +71,8 @@ final class Cascade_Accessor_KVS_TestMemcached01
 
         // -----------------------------
         $data_01 = $accessor->set($key, $value);
-        $data_02 = array_shift($accessor->get($key));
+        $actual_key = $accessor->get($key);
+        $data_02 = array_shift($actual_key);
 
         // -----------------------------
         $this->assertTrue($data_01);
@@ -89,7 +90,8 @@ final class Cascade_Accessor_KVS_TestMemcached01
         // -----------------------------
         $data_01 = $accessor->add($key, $value);
         $data_02 = $accessor->set($key, $value = 20000);
-        $data_03 = array_shift($accessor->get($key));
+        $actual_key = $accessor->get($key);
+        $data_03 = array_shift($actual_key);
 
         // -----------------------------
         $this->assertTrue($data_01);
@@ -107,7 +109,8 @@ final class Cascade_Accessor_KVS_TestMemcached01
 
         // -----------------------------
         $data_01 = $accessor->replace($key, $value);
-        $data_02 = array_shift($accessor->get($key));
+        $actual_key = $accessor->get($key);
+        $data_02 = array_shift($actual_key);
 
         // -----------------------------
         $this->assertFalse($data_01);
@@ -125,7 +128,8 @@ final class Cascade_Accessor_KVS_TestMemcached01
         // -----------------------------
         $data_01 = $accessor->add($key, $value);
         $data_02 = $accessor->replace($key, $value = 20000);
-        $data_03 = array_shift($accessor->get($key));
+        $actual_key = $accessor->get($key);
+        $data_03 = array_shift($actual_key);
 
         // -----------------------------
         $this->assertTrue($data_01);
@@ -149,7 +153,8 @@ final class Cascade_Accessor_KVS_TestMemcached01
             $cas_token
         ) = $accessor->get($key);
         $data_03 = $accessor->cas($cas_token, $key, $value_02);
-        $data_04 = array_shift($accessor->get($key));
+        $actual_key = $accessor->get($key);
+        $data_04 = array_shift($actual_key);
 
         // -----------------------------
         $this->assertTrue($data_01);
@@ -197,9 +202,11 @@ final class Cascade_Accessor_KVS_TestMemcached01
             $cas_token
         ) = $accessor->get($key);
         $data_03 = $accessor->set($key, $value_02);
-        $data_04 = array_shift($accessor->get($key));
+        $actual_key = $accessor->get($key);
+        $data_04 = array_shift($actual_key);
         $data_05 = $accessor->cas($cas_token, $key, $value_03);
-        $data_06 = array_shift($accessor->get($key));
+        $actual_key = $accessor->get($key);
+        $data_06 = array_shift($actual_key);
 
         // -----------------------------
         $this->assertTrue($data_01);
@@ -227,7 +234,8 @@ final class Cascade_Accessor_KVS_TestMemcached01
         ) = $accessor->get($key);
         $accessor->delete($key);
         $data_03 = $accessor->cas($cas_token, $key, $value_02);
-        $data_04 = array_shift($accessor->get($key));
+        $actual_key = $accessor->get($key);
+        $data_04 = array_shift($actual_key);
 
         // -----------------------------
         $this->assertTrue($data_01);
@@ -269,7 +277,7 @@ final class Cascade_Accessor_KVS_TestMemcached01_DataFormat
     // @var string DSN
     protected $dsn          = 'gree(memcache)://node/test';
     // @var int    DB接続ドライバー種別
-    protected $driver_type  = self::DRIVER_LIBMEMCACHED;
+    protected $driver_type  = self::DRIVER_MEMCACHED;
     // @var string  namespace
     protected $namespace    = 'cascade#test';
     // @var boolean The data compressed flag

--- a/test/etc/cascade.ini.php
+++ b/test/etc/cascade.ini.php
@@ -1,0 +1,74 @@
+<?php
+return $cascade_config = array(
+    'system' => array(
+        // {{{ log
+        'log' => array(
+            'level' => 7,
+            'dir'   => array(
+                'default' => '/tmp/cascade',
+                'emerg'   => NULL,
+                'alert'   => NULL,
+                'crit'    => NULL,
+                'err'     => NULL,
+                'warning' => NULL,
+                'notice'  => NULL,
+                'info'    => NULL,
+                'debug'   => NULL,
+            ),
+        ),
+        // }}}
+        // {{{ log#sql
+        'log#sql : log' => array(
+            'dir' => array(
+                'default' => '/tmp/cascade/mysql',
+            ),
+        ),
+        // }}}
+        // {{{ log#kvs
+        'log#kvs : log' => array(
+            'dir' => array(
+                'default' => '/tmp/cascade/kvs',
+            ),
+        ),
+        // }}}
+        // {{{ dsn-config-gree
+        'dsn-config-gree' => array(
+            // gree(mysql)
+            'mysql.var'     => 'db_config_list',
+            'mysql.path'    => dirname(__FILE__).'/mysql.ini.php',
+            // gree(memcache)
+            'memcache.var'  => 'memcache_config_list',
+            'memcache.path' => dirname(__FILE__).'/memcache.ini.php',
+            // gree(flare)
+            'flare.var'     => 'flare_config_list',
+            'flare.path'    => dirname(__FILE__).'/flare.ini.php',
+        ),
+        // }}}
+    ),
+    'schema' => array(
+        // {{{ default
+        'default' => array(
+            'dataformat' => array(
+                'prefix' => 'Cascade_DataFormat_',
+                'suffix' => NULL,
+            ),
+            'gateway'    => array(
+                'prefix' => 'Cascade_Gateway_',
+                'suffix' => NULL,
+            ),
+        ),
+        // }}}
+        // {{{ test
+        'test' => array(
+            'dataformat' => array(
+                'prefix' => 'Cascade_',
+                'suffix' => '_DataFormat',
+            ),
+            'gateway'    => array(
+                'prefix' => 'Cascade_',
+                'suffix' => '_Gateway',
+            ),
+        ),
+        // }}}
+    ),
+);

--- a/test/etc/flare.ini.php
+++ b/test/etc/flare.ini.php
@@ -1,0 +1,10 @@
+<?php
+return $flare_config_list = array(
+    'default' => array(
+    ),
+    'test' => array(
+        'node' => array(
+            'localhost:11211',
+        ),
+    ),
+);

--- a/test/etc/memcache.ini.php
+++ b/test/etc/memcache.ini.php
@@ -1,0 +1,10 @@
+<?php
+return $memcache_config_list = array(
+    'default' => array(
+    ),
+    'test' => array(
+        'node' => array(
+            'localhost:11211',
+        ),
+    ),
+);

--- a/test/etc/mysql.ini.php
+++ b/test/etc/mysql.ini.php
@@ -1,0 +1,17 @@
+<?php
+return $db_config_list = array(
+    'default' => array(
+        'user'      => 'travis',
+        'pass'      => '',
+        'ro_user'   => 'travis',
+        'ro_pass'   => '',
+    ),
+    'test' => array(
+        'master'    => 'localhost:3306',
+        'slave'     => array(
+            'localhost:3306',
+        ),
+        'standby'   => 'localhost:3306',
+        'db'        => 'cascade_test_on_travis',
+    ),
+);


### PR DESCRIPTION
travis-ciと統合用のです。これをmeregeすると5.2 ~ 5.5まで自動的にテストが行えるようになります。
### 主な変更点
- 5.4向けの修正を追加
- TestMemcachedのDriverをMemcached Driverに変更
- test用のiniの追加
- travisのbuild statusの追加
- phpunitのデフォルト設定としてphpunit.xml.distを追加
- test用のbootstrapにtravis用の設定を追加
### あとでやること
- travisの設定をONにする
